### PR TITLE
automate env setup & controller deployment for effective testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
-COPY api/ api/
+# COPY api/ api/
 COPY internal/controller/ internal/controller/
 
 # Build

--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ teardown-env: ## Teardown the k3d environment.
 
 .PHONY: stop-env
 stop-env: ## Stop the k3d environment.
-	@if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}""; then \
+	@if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}"; then \
 		if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}.*1/1"; then \
 			echo "${K3D_CLUSTER_NAME} is running in k3d..."; \
 			k3d cluster stop ${K3D_CLUSTER_NAME}; \

--- a/Makefile
+++ b/Makefile
@@ -320,3 +320,115 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+.PHONY: setup-env
+setup-env: ## Setup the environment for run the controller.
+	@if ! command -v docker &> /dev/null; then \
+		echo "Docker not found, installing..."; \
+		sudo apt-get update; \
+		sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common; \
+		curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -; \
+		sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"; \
+		sudo apt-get update; \
+		sudo apt-get install -y docker-ce; \
+		sudo usermod -aG docker $$(whoami); \
+		echo "Docker installed successfully. Please log out and log back in for the changes to take effect."; \
+	else \
+		echo "Docker is already installed..."; \
+	fi
+
+	@if ! command -v k3d &> /dev/null; then \
+		echo "k3d not found, installing..."; \
+		curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash; \
+	else \
+		echo "k3d is already installed..."; \
+	fi
+
+	@if ! command -v kubectl &> /dev/null; then \
+		echo "kubectl not found, installing..."; \
+		curl -LO "https://dl.k8s.io/release/$(shell curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; \
+		chmod +x kubectl; \
+		sudo mv kubectl /usr/local/bin/; \
+	else \
+		echo "kubectl is already installed..."; \
+	fi
+
+	@if ! command -v helm &> /dev/null; then \
+		echo "Helm not found, installing..."; \
+		curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash; \
+	else \
+		echo "Helm is already installed..."; \
+	fi
+
+	@if k3d cluster list | grep -q 'test-cluster'; then \
+		echo "Test-cluster is available in k3d..."; \
+	else \
+		echo "Test cluster not found in k3d, creating..."; \
+		k3d cluster create test-cluster -v "${PWD}:/workspace@agent:*" -v "${PWD}:/workspace@server:*"; \
+	fi
+
+	@if k3d cluster list test-cluster | grep -q '1/1'; then \
+		echo "Test-cluster is running..."; \
+	else \
+		echo "Test-cluster is not running, starting..."; \
+		k3d cluster start test-cluster; \
+	fi;
+
+	@if kubectl config current-context | grep -q 'k3d-test-cluster'; then \
+		echo "Context is already set to test-cluster..."; \
+	else \
+		echo "Setting context to test-cluster..."; \
+		kubectl config use-context k3d-test-cluster; \
+	fi
+
+	@if kubectl get deployments -n argo | grep -qE '^argo-argo-workflows-workflow-controller.*1/1|^argo-argo-workflows-server.*1/1'; then \
+		echo "Argo Workflows is already running in the argo namespace..."; \
+	else \
+		echo "Argo Workflows is not running in the argo namespace..."; \
+		helm repo add argo https://argoproj.github.io/argo-helm; \
+		helm repo update; \
+		helm install argo argo/argo-workflows -n argo --create-namespace; \
+		while true; do \
+			if kubectl get deployments -n argo | grep -qE '^argo-argo-workflows-workflow-controller.*1/1|^argo-argo-workflows-server.*1/1'; then \
+				echo "Argo Workflows is running in the argo namespace..."; \
+				break; \
+			else \
+				echo "Waiting for Argo Workflows to be running in the argo namespace..."; \
+				sleep 5; \
+			fi; \
+		done; \
+	fi
+
+	@if kubectl get ns | grep -q 'argo-slsa'; then \
+		echo "Namespace argo-slsa is already available..."; \
+		kubectl config set-context --current --namespace=argo-slsa; \
+	else \
+		echo "Creating namespace argo-slsa..."; \
+		kubectl create ns argo-slsa; \
+		kubectl config set-context --current --namespace=argo-slsa; \
+	fi
+
+	@if kubectl get role argo-workflow-role -n argo-slsa &> /dev/null && kubectl get rolebinding argo-workflow-rolebinding -n argo-slsa &> /dev/null; then \
+		echo "Role and Rolebinding for Argo Workflows are already available in the argo-slsa namespace..."; \
+	else \
+		echo "Creating Role and Rolebinding for Argo Workflows in the argo-slsa namespace..."; \
+		kubectl apply -f test/workflow/rbac/workflows-rbac.yaml; \
+	fi
+
+	@if kubectl get secret docker-hub-credentials &> /dev/null; then \
+		echo "Secret docker-hub-credentials is already available..."; \
+	else \
+		echo "Creating secret docker-hub-credentials..."; \
+		read -p "Enter Docker Hub Username: " DOCKER_USERNAME; \
+		read -s -p "Enter Docker Hub Password: " DOCKER_PASSWORD; \
+		kubectl create secret docker-registry docker-hub-credentials --docker-server=https://index.docker.io/v1/ --docker-username=$$DOCKER_USERNAME --docker-password=$$DOCKER_PASSWORD; \
+	fi
+
+.PHONY: teardown-env
+teardown-env: ## Teardown the environment for run the controller.
+	@if k3d cluster list | grep -q 'test-cluster'; then \
+		echo "Test-cluster is available in k3d..."; \
+		k3d cluster delete test-cluster; \
+	else \
+		echo "Test-cluster is not available in k3d..."; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -321,8 +321,10 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
+K3D_CLUSTER_NAME ?= test-cluster
+
 .PHONY: setup-env
-setup-env: ## Setup the environment for run the controller.
+setup-env: ## Setup the environment with k3d to run the controller.
 	@if ! command -v docker &> /dev/null; then \
 		echo "Docker not found, installing..."; \
 		sudo apt-get update; \
@@ -360,25 +362,25 @@ setup-env: ## Setup the environment for run the controller.
 		echo "Helm is already installed..."; \
 	fi
 
-	@if k3d cluster list | grep -q 'test-cluster'; then \
-		echo "Test-cluster is available in k3d..."; \
+	@if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}"; then \
+		echo "${K3D_CLUSTER_NAME} is available in k3d..."; \
 	else \
 		echo "Test cluster not found in k3d, creating..."; \
-		k3d cluster create test-cluster -v "${PWD}:/workspace@agent:*" -v "${PWD}:/workspace@server:*"; \
+		k3d cluster create ${K3D_CLUSTER_NAME} -v "${PWD}:/workspace@agent:*" -v "${PWD}:/workspace@server:*"; \
 	fi
 
-	@if k3d cluster list test-cluster | grep -q '1/1'; then \
-		echo "Test-cluster is running..."; \
+	@if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}.*1/1"; then \
+		echo "${K3D_CLUSTER_NAME} is running..."; \
 	else \
-		echo "Test-cluster is not running, starting..."; \
-		k3d cluster start test-cluster; \
+		echo "${K3D_CLUSTER_NAME} is not running, starting..."; \
+		k3d cluster start ${K3D_CLUSTER_NAME}; \
 	fi;
 
-	@if kubectl config current-context | grep -q 'k3d-test-cluster'; then \
-		echo "Context is already set to test-cluster..."; \
+	@if kubectl config current-context | grep -q "k3d-${K3D_CLUSTER_NAME}"; then \
+		echo "Context is already set to ${K3D_CLUSTER_NAME}..."; \
 	else \
-		echo "Setting context to test-cluster..."; \
-		kubectl config use-context k3d-test-cluster; \
+		echo "Setting context to ${K3D_CLUSTER_NAME}..."; \
+		kubectl config use-context k3d-${K3D_CLUSTER_NAME}; \
 	fi
 
 	@if kubectl get deployments -n argo | grep -qE '^argo-argo-workflows-workflow-controller.*1/1|^argo-argo-workflows-server.*1/1'; then \
@@ -425,10 +427,48 @@ setup-env: ## Setup the environment for run the controller.
 	fi
 
 .PHONY: teardown-env
-teardown-env: ## Teardown the environment for run the controller.
-	@if k3d cluster list | grep -q 'test-cluster'; then \
-		echo "Test-cluster is available in k3d..."; \
-		k3d cluster delete test-cluster; \
+teardown-env: ## Teardown the k3d environment.
+	@if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}"; then \
+		echo "${K3D_CLUSTER_NAME} is available in k3d..."; \
+		k3d cluster delete ${K3D_CLUSTER_NAME}; \
 	else \
-		echo "Test-cluster is not available in k3d..."; \
+		echo "${K3D_CLUSTER_NAME} is not available in k3d..."; \
 	fi
+
+.PHONY: stop-env
+stop-env: ## Stop the k3d environment.
+	@if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}""; then \
+		if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}.*1/1"; then \
+			echo "${K3D_CLUSTER_NAME} is running in k3d..."; \
+			k3d cluster stop ${K3D_CLUSTER_NAME}; \
+		else \
+			echo "${K3D_CLUSTER_NAME} is already stoped..."; \
+		fi; \
+	else \
+		echo "${K3D_CLUSTER_NAME} is not available in k3d..."; \
+		exit 1; \
+	fi
+
+.PHONY: start-env
+start-env: ## Start the k3d environment.
+	@if k3d cluster list | grep -q "${K3D_CLUSTER_NAME}"; then \
+		if k3d cluster list ${K3D_CLUSTER_NAME} | grep -q "${K3D_CLUSTER_NAME}.*1/1"; then \
+			echo "${K3D_CLUSTER_NAME} is already running in k3d..."; \
+		else \
+			echo "${K3D_CLUSTER_NAME} is not running in k3d, starting..."; \
+			k3d cluster start ${K3D_CLUSTER_NAME}; \
+		fi; \
+	else \
+		echo "${K3D_CLUSTER_NAME} is not available in k3d..."; \
+		exit 1; \
+	fi
+
+.PHONY: import-image-to-k3d
+import-image-to-k3d: ## Import the controller image to the k3d cluster.
+	k3d image import ${IMG} -c ${K3D_CLUSTER_NAME} -m direct
+
+.PHONY: build-and-deploy-controller
+build-and-deploy-controller: ## Build and deploy the controller to the k3d cluster.
+	$(MAKE) docker-build
+	$(MAKE) import-image-to-k3d
+	$(MAKE) deploy

--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,7 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
+##@ Environment
 K3D_CLUSTER_NAME ?= test-cluster
 
 .PHONY: setup-env
@@ -472,3 +473,7 @@ build-and-deploy-controller: ## Build and deploy the controller to the k3d clust
 	$(MAKE) docker-build
 	$(MAKE) import-image-to-k3d
 	$(MAKE) deploy
+
+.PHONY: remove-controller
+remove-controller: ## Remove the controller from the k3d cluster
+	$(MAKE) undeploy

--- a/README.md
+++ b/README.md
@@ -1,46 +1,6 @@
 # argo-supply-chain-security
 This project will focus on integrating software supply chain security into argo workflows
 
-### Setup the environment
-will use k3d this requires docker 
-``` sh
-k3d cluster create test -v "${PWD}:/workspace@agent:*" -v "${PWD}:/workspace@server:*"
-```
-#### Stop or Start the cluster
-``` sh
-# Stop the cluster
-k3d cluster stop test
-
-# Start the cluster
-k3d cluster start test
-```
-### install argo workflows in your cluster
-``` sh
-helm repo add argo https://argoproj.github.io/argo-helm
-helm repo update
-helm install argo argo/argo-workflows -n argo --create-namespace
-```
-#### Create a namespace
-``` sh
-# this will be used to run the argo workflows
-kubectl create namespace argo-slsa
-
-# set the namespace as default
-kubectl config set-context --current --namespace=argo-slsa
-
-# set rbac for the namespaced sa
-kubectl apply -f test/workflow/rbac/workflows-rbac.yaml
-```
-#### Create docker hub credentials
-``` sh
-kubectl create secret docker-registry docker-hub-credentials --docker-server=https://index.docker.io/v1/ --docker-username=<username> --docker-password=<password> --docker-email=<email>
-```
-#### Create keys for signing
-``` sh
-# create a key pair
-cosign generate-key-pair k8s://<NAMESPACE>/<KEY>
-```
-
 # Controller creation process
 Source : https://kubernetes.io/blog/2021/06/21/writing-a-controller-for-pod-labels/
 
@@ -57,9 +17,24 @@ operator-sdk create api --group=argoproj.io --version=v1alpha1 --kind=Workflow -
 ```
 
 ### test the controller by running it
+#### Setup the environment
+will use k3d this requires docker 
+``` sh
+make setup-env
+```
+
+#### Run the controller
 ``` sh
 make run
+```
 
+#### Create a sample workflow to reconcile by the controller
+``` sh
 # run the workflow so controller can reconcile it update status & list the pod names of the workflow
 kubectl create -f test/workflow/build-and-push-docker.yaml
+```
+
+#### Clean up environment
+``` sh
+make teardown-env
 ```

--- a/README.md
+++ b/README.md
@@ -23,15 +23,30 @@ will use k3d this requires docker
 make setup-env
 ```
 
-#### Run the controller
+#### Build & deploy the controller locally
 ``` sh
-make run
+make build-and-deploy-controller
 ```
 
 #### Create a sample workflow to reconcile by the controller
 ``` sh
 # run the workflow so controller can reconcile it update status & list the pod names of the workflow
 kubectl create -f test/workflow/build-and-push-docker.yaml
+```
+
+#### remove the controller
+``` sh
+make undeploy
+```
+
+#### stop the environment
+``` sh
+make stop-env
+```
+
+#### start the environment
+``` sh
+make start-env
 ```
 
 #### Clean up environment

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ make build-and-deploy-controller
 kubectl create -f test/workflow/build-and-push-docker.yaml
 ```
 
+### Aditional commands
 #### remove the controller
 ``` sh
-make undeploy
+make remove-controller
 ```
 
 #### stop the environment

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,6 +63,7 @@ spec:
         args:
         - --leader-elect
         image: controller:latest
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,13 +7,20 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods/log
+  - pods
   verbs:
   - get
   - list
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/workflow_controller.go
+++ b/internal/controller/workflow_controller.go
@@ -44,7 +44,8 @@ const (
 
 //+kubebuilder:rbac:groups=argoproj.io,resources=workflows,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list
-//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get;list
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;update;patch
 
 // update current status in workflow
 func updateWFStatus(r *WorkflowReconciler, ctx context.Context, wf *wfv1alpha1.Workflow, label string, status string) (ctrl.Result, error) {


### PR DESCRIPTION
Update makefile to support:

- Kubernetes env creation & teardown
- build & deploy controller within the cluster
- separate all env-related options into separate sections when "make help" is executed

Update readme with usage